### PR TITLE
Spelling mistake in tutorial

### DIFF
--- a/PhysicalModels/NumberUncertainties.ipynb
+++ b/PhysicalModels/NumberUncertainties.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "There is a Julia package for dealing with numbers with uncertainties: [`Measurements.jl`](https://github.com/JuliaPhysics/Measurements.jl).  Thanks to Julia's features, `DifferentialEquations.jl` easily works together with `Measurements.jl` out-of-the-box.\n",
     "\n",
-    "This notebook will cover some of the examples from the tutorial about lassical Physics."
+    "This notebook will cover some of the examples from the tutorial about classical Physics."
    ]
   },
   {


### PR DESCRIPTION
Changed "lassical physics" to "classical physics".