### PR TITLE
gitignore weaved output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *.out
 *.tex
 Manifest.toml
+tutorials/**/*.html
+tutorials/**/*.pdf


### PR DESCRIPTION
Since the weaved output should not be committed, I added it to .gitignore.
I think this could be helpful for contributors.